### PR TITLE
Tienda2019: añadir soporte para número de teléfono fijo y móvil.

### DIFF
--- a/web/js/jsStore/jsController/indexController.js
+++ b/web/js/jsStore/jsController/indexController.js
@@ -26,6 +26,7 @@
         STORE.Error = STORE.managementError();
         STORE.Submit = STORE.managementSubmit();
         STORE.strategyOneByOne();
+        STORE.Prefijos();
 
         $("submit").addEventListener("click", function () {
             var envio = {

--- a/web/js/jsStore/template/IndexTemplate.js
+++ b/web/js/jsStore/template/IndexTemplate.js
@@ -20,7 +20,7 @@ STORE.IndexTemplate = {
         "            </div>" +
         "            <div id='div_mobile'>" +
         "                <label for='mobile'></label>" +
-        "                <select id='prefijo'></select>" +
+        "                <select id='prefijoMovil'></select>" +
         "                <input class='etiqueta s8' id='mobile' name='movilCliente' value='' type='tel' data-functioncallback='ValidacionExpresionRegular.validarTelefonoFijo' size='20' required placeholder='Tlf Movil' title='Tlf Movil'>" + /*"ValidacionExpresionRegular.validarNumeroMovil"*/
         "            </div>" +
         "            <div id='div_email'>" +

--- a/web/js/jsStore/util/prefijos.js
+++ b/web/js/jsStore/util/prefijos.js
@@ -1,49 +1,83 @@
-(function(g){
+STORE.namespace('STORE.Prefijos');
+STORE.namespace('STORE.prefix_input');
+STORE.Prefijos = function(){
     'use strict';
 
-    STORE.Utiles = {
-        cambiarExpRegular() {
-            var selectedValue = prefijo.options[prefijo.selectedIndex].valueOf().innerText;
+    var campoMovil = "mobile"; //1 es movil
+    var campoFijo = "phone"; //2 es fijo
+
+    // Lista de expresiones regulares.
+    const NUMERO_SPAIN_MOVIL = /^[6|7][0-9]{8}$/;
+    const NUMERO_US_MOVIL = /^[0-9]{10}$/;
+    const NUMERO_SPAIN_FIJO = /^[9][0-9]{8}$/;
+    const NUMERO_US_FIJO = /^[0-9]{10}$/;
+
+    // Objeto prefijo con todos los refijos soportados.
+    const PREFIJOS = [
+        { "prefijo": "US", "value": "+1", "maximo": 10, "flag" : "us.png", "expresionRegularMovil": NUMERO_US_MOVIL, "expresionRegularFijo": NUMERO_US_FIJO},
+        { "default" : true, "prefijo": "ES", "value": "+34", "maximo": 9, "flag": "spain.png", "expresionRegularMovil": NUMERO_SPAIN_MOVIL, "expresionRegularFijo": NUMERO_SPAIN_FIJO}
+    ];
+
+    var cambiarExpRegular = function(tipo) {
+            // Usamos este valor para saber que tipo de campo es.
+            let campoLimite = null;
+
+            console.log(tipo);
+
+            if (tipo === 1) {
+                campoLimite = campoMovil;
+                var selectedValue = prefijo.options[prefijo.selectedIndex].value;
+            }
+
+            if (tipo === 2) {
+                campoLimite = campoFijo;
+                var selectedValue = prefijoFijo.options[prefijoFijo.selectedIndex].value;
+            }
+
             console.log(selectedValue);
             for (var index in PREFIJOS) {
                 if (PREFIJOS[index].value === selectedValue) {
-                    STORE.prefix_input.regExp = PREFIJOS[index].expresionRegularMovil;
+                    STORE.prefix_input.regExpMovil = PREFIJOS[index].expresionRegularMovil;
+                    STORE.prefix_input.regExpFijo = PREFIJOS[index].expresionRegularFijo;
                     STORE.prefix_input.minimo = PREFIJOS[index].minimo;
                     STORE.prefix_input.maximo = PREFIJOS[index].maximo;
-                    STORE.Utiles.limitarCamposDeTexto("numeroMovil", PREFIJOS[index].maximo);
+                    limitarCamposDeTexto(campoLimite, PREFIJOS[index].maximo);
                 }
             }
-        },
-        limitarCamposDeTexto : function (campo, limite) {
+        };
+
+    var limitarCamposDeTexto = function (campo, limite) {
             document.getElementById(campo).setAttribute("maxlength", limite);
+        };
+
+    const prefijoFijo = document.getElementById('prefijoFijo');
+
+    for (var index in PREFIJOS) {
+        prefijoFijo.options[prefijoFijo.options.length] = new Option(PREFIJOS[index].prefijo, PREFIJOS[index].value, undefined, PREFIJOS[index].default);
+        if (PREFIJOS[index].default) {
+            STORE.prefix_input.regExpFijo = PREFIJOS[index].expresionRegularFijo;
+            limitarCamposDeTexto(campoFijo, PREFIJOS[index].maximo);
         }
-
     }
 
-}) (window,undefined);
+    const prefijo = document.getElementById('prefijoMovil');
 
-// Lista de expresiones regulares.
-const NUMERO_SPAIN_MOVIL = /^[6|7][0-9]{8}$/;
-const NUMERO_US_MOVIL = /^[0-9]{10}$/;
-
-// Objeto prefijo con todos los refijos soportados.
-const PREFIJOS = [
-    {"prefijo": "ES", "value": "+34", "maximo": "9", "flag": "spain.png", "expresionRegularMovil": NUMERO_SPAIN_MOVIL},
-    {"prefijo": "US", "value": "+1", "maximo": "10", "flag" : "us.png", "expresionRegularMovil": NUMERO_US_MOVIL, "default" : "true"}
-];
-
-STORE.namespace('STORE.prefix_input');
-
-STORE.prefix_input = document.getElementById("prefijo");
-var prefijo = STORE.prefix_input;
-for(var index in PREFIJOS) {
-    prefijo.options[prefijo.options.length] = new Option(PREFIJOS[index].value, index, PREFIJOS[index].default, PREFIJOS[index].default);
-    if (PREFIJOS[index].default) {
-        STORE.prefix_input.regExp = PREFIJOS[index].expresionRegularMovil;
-        STORE.Utiles.limitarCamposDeTexto("numeroMovil", PREFIJOS[index].maximo);
-        console.log("El valor por defecto es: " + PREFIJOS[index].prefijo);
+    for (var index in PREFIJOS) {
+        prefijo.options[prefijo.options.length] = new Option(PREFIJOS[index].prefijo, PREFIJOS[index].value, undefined, PREFIJOS[index].default);
+        if (PREFIJOS[index].default) {
+            STORE.prefix_input.regExpMovil = PREFIJOS[index].expresionRegularMovil;
+            limitarCamposDeTexto(campoMovil, PREFIJOS[index].maximo);
+        }
     }
-    console.log("Añadida opcion");
-}
-// Action Listener para cambios de prefijo.
-prefijo.addEventListener("change", STORE.Utiles.cambiarExpRegular);
+
+    // Action Listener para cambios de prefijo para número móvil.
+    prefijoFijo.addEventListener("change", function () {
+        cambiarExpRegular(2);
+    });
+
+    // Action Listener para cambios de prefijo para número fijo.
+    prefijo.addEventListener("change", function () {
+        cambiarExpRegular(1);
+    });
+
+};

--- a/web/js/jsStore/util/validate.js
+++ b/web/js/jsStore/util/validate.js
@@ -465,7 +465,7 @@ STORE.namespace('STORE.ValidacionExpresionRegular');
 
             parametro.nodo = evt.target;
 
-            parametro.patron = STORE.prefix_input.regExp;
+            parametro.patron = STORE.prefix_input.regExpMovil;
 
             parametro.maximo = STORE.prefix_input.maximo;
 
@@ -494,12 +494,13 @@ STORE.namespace('STORE.ValidacionExpresionRegular');
 
             parametro.nodo = evt.target;
 
-            parametro.patron = "^(\\+34|0034|34)?[6789]\\d{8}$";
+            parametro.patron = STORE.prefix_input.regExpFijo;
 
-            parametro.mensajeError = "Teléfono Fijo NO válido";
+            parametro.maximo = STORE.prefix_input.maximo;
 
-            STORE.ValidacionUtil.valorarConsecuencia(STORE.ValidacionUtil.validarExpRegular(parametro), parametro);
+            parametro.mensajeError = ("ERROR: El número de teléfono fijo debe tener: " + parametro.maximo + " dígitos");
 
+            STORE.ValidacionUtil.valorarConsecuencia(STORE.ValidacionUtil.validarExpRegular(parametro),parametro);
         },
 
         validarUsuario: function (evt) {


### PR DESCRIPTION
Esto permitirá dentro de una misma clase:

* Cambiar el valor de los prefijos al cambiar entre ellos en la vista.
* Popular la lista de Prefijos(mediante PREFIJOS)
* Limitar el tamaño máximo permitido de carácteres según la longitud de la expresion
regular por cada país.

Por la estructura del archivo tenemos PREFIJOS, que es un objeto formado por un array
de objetos, cada uno de estos incluye:

* prefijo : string = Para fácil identificación del país. Ej: "ES"
* value : string = Es el identificador del país. Ej: "+34"
* maximo : number = Es el número máximo de carácteres que soporta el prefijo. Ej: 9
* flag : string = Sirve para añadir una ruta para poner una bandera en el select. Ej: "spain.png" //SIN TERMINAR.
* expresionRegularMovil : regExp = aquí insertaremos la expresion regular a usar para teléfono móvil. Ej: /^[6|7][0-9]{8}$/
* expresionRegularFijo : regExp = aquí insertaremos la expresion regular a usar para teléfono fijo. Ej: /^[9][0-9]{8}$/
* default : boolean = esto nos servirá para marcar que prefijo queremos que salga por defecto al abrir la web. Ej: "true"

cambiarExpRegular() : Se encarga de cambiar la expresión regular a nivel de STORE cada vez que cambiamos de prefijo, incluyendo
todas las propiedas del país seleccionado. A su vez este llama a limitarCamposDeTexto(), que limita el número máximo de caracteres
a insertar, basándose en el parámetro 'maximo' de la expresión regular seleccionada.

Signed-off-by: Hernán Castañón <herna@paranoidandroid.co>